### PR TITLE
Arreglado problema de permisos y ejecucion como root

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-echo " "
-echo "$(tput setaf 3)[+]Instalaremos: curl, figlet y wpuserenum (en su sistema)."
-echo "$(tput setaf 2) "
-sudo apt install curl
-sudo apt install figlet
-cp wpuserenum /usr/bin/
+if [ $EUID -ne 0 ]; then
+	echo " "
+	echo "$(tput setaf 3)[+]Ejecuta el script como root"
+	exit 1
+fi
 
+tools=(curl figlet)
+
+echo " "
+echo "$(tput setaf 3)[+] Instalaremos: curl, figlet y wpuserenum (en su sistema)."
+
+for tool in ${tools[@]}; do
+	sudo apt install $tool -y > /dev/null 2>&1
+done
 
 chmod +x wpuserenum
+cp wpuserenum /usr/bin/
 
 echo " "
-echo "$(tput setaf 3)[V]Completado."
-echo " "
+echo "$(tput setaf 3)[V] Completado."


### PR DESCRIPTION
Cuando se ejecutaba el script setup.sh copiaba wpuserenum  a /usr/bin/ antes de que asignara permisos de ejecución por lo que no podía ejecutarse wpuserenum sin referenciar al path, además se ha añadido que solamente pueda ser ejecutado como usuario root.